### PR TITLE
Freeze sidekiq_label constant to prevent unnecessary allocations

### DIFF
--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
     def safe_thread(name, &block)
       Thread.new do
-        Thread.current['sidekiq_label'] = name
+        Thread.current['sidekiq_label'.freeze] = name
         watchdog(name, &block)
       end
     end


### PR DESCRIPTION
In examining some of our object dumps, noticed that `sidekiq_label` was being allocated and cleaned up a bit frequently.
